### PR TITLE
[SWM-102] chore: set up Docker Compose MySQL for dev and H2 for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,4 +38,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	jvmArgs += "-Dspring.profiles.active=test"
 }

--- a/docker/dev/mysql/docker-compose.yml
+++ b/docker/dev/mysql/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  mysql-dev:
+    image: mysql:9.3.0
+    container_name: mysql-dev
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER:     ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_dev_data:/var/lib/mysql
+
+volumes:
+  mysql_dev_data:

--- a/src/main/resources/application-db-dev.yml
+++ b/src/main/resources/application-db-dev.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: db-dev
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/climbx?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+
+    username: ${MYSQL_USER:dev_user}
+    password: ${MYSQL_PASSWORD:dev_password}

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+    hikari:
+      minimum-idle: 5
+      maximum-pool-size: 20
+      auto-commit: false
+
+    url: ${DB_URL:jdbc:mysql://localhost:3306/climbx?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true}
+
+    username: ${DB_USER:root}
+    password: ${DB_PASSWORD:password}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+logging:
+  level:
+    root: INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ClimbX

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+spring:
+  profiles:
+    active: dev
+
+    group:
+      dev:
+        - db-dev
+
+    include:
+      - db
+
+  jpa:
+    generate-ddl: true
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        use_sql_comments: true
+
+server:
+  port: 8080
+
+logging:
+  level:
+    root: INFO

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:climbx_test;DB_CLOSE_DELAY=-1;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- Dev environment uses MySQL via Docker Compose, creds from MYSQL_USER / MYSQL_PASSWORD
- Test profile uses in-memory H2 with ddl-auto=create-drop

## 📋 앞으로의 과제 (Todo)
[1] 테스트에서도 도커 mysql 사용