### PR TITLE
[SWM-89] feat: 클라이밍장 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/climbx/climbx/gym/GymController.java
+++ b/src/main/java/com/climbx/climbx/gym/GymController.java
@@ -4,10 +4,13 @@ import com.climbx.climbx.gym.dto.GymInfoResponseDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class GymController {
 
     private final GymService gymService;
+
+    @GetMapping("/{gymId}")
+    public @Valid GymInfoResponseDto getGymById(@PathVariable @NotNull @Min(1L) Long gymId) {
+        return gymService.getGymById(gymId);
+    }
 
     @GetMapping(params = {"!latitude", "!longitude"})
     public List<@Valid GymInfoResponseDto> getGymList(

--- a/src/main/java/com/climbx/climbx/gym/GymService.java
+++ b/src/main/java/com/climbx/climbx/gym/GymService.java
@@ -1,6 +1,7 @@
 package com.climbx.climbx.gym;
 
 import com.climbx.climbx.gym.dto.GymInfoResponseDto;
+import com.climbx.climbx.gym.exception.GymNotFoundException;
 import com.climbx.climbx.gym.repository.GymRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,12 @@ import org.springframework.stereotype.Service;
 public class GymService {
 
     private final GymRepository gymRepository;
+
+    public GymInfoResponseDto getGymById(Long gymId) {
+        return gymRepository.findById(gymId)
+            .map(GymInfoResponseDto::from)
+            .orElseThrow(() -> new GymNotFoundException(gymId));
+    }
 
     public List<GymInfoResponseDto> getGymList(String keyword) {
 

--- a/src/main/java/com/climbx/climbx/gym/entity/GymEntity.java
+++ b/src/main/java/com/climbx/climbx/gym/entity/GymEntity.java
@@ -60,7 +60,7 @@ public class GymEntity extends BaseTimeEntity {
     @Column(name = "description", length = 200)
     private String description; // 상세 설명
 
-    @Column(name = "2d_map_url", length = 255)
+    @Column(name = "map_2d_url", length = 255)
     private String map2DUrl; // 2D 지도 URL
 
     // Todo : 매장 메타데이터 json 컬럼

--- a/src/main/java/com/climbx/climbx/gym/exception/GymNotFoundException.java
+++ b/src/main/java/com/climbx/climbx/gym/exception/GymNotFoundException.java
@@ -1,0 +1,12 @@
+package com.climbx.climbx.gym.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class GymNotFoundException extends RuntimeException {
+    
+    public GymNotFoundException(Long gymId) {
+        super("Gym not found with id: " + gymId);
+    }
+} 


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 클라이밍장의 상세 정보들을 조회하는 GET API 구현

## ✅ 테스트 방법 (How to Test)
- 서비스코드 단위 테스트 작성

## 💬 리뷰어에게 (To Reviewer)

- 별도 이슈로 뽑기에는 너무 작은 단위였던 것 같네요.. 별 문제 없다면 머지 부탁드립니다 :)

## 🚀관련 이슈 (Related Issue)
Closes: SWM-89