### PR TITLE
[SWM-111] fix: getUserDailyHistory 쿼리 group by 추가

### DIFF
--- a/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
+++ b/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
@@ -25,6 +25,7 @@ public interface UserRankingHistoryRepository extends
            AND h.part = :criteria
            AND (:from IS NULL OR DATE(h.createdAt) >= :from)
            AND (:to IS NULL OR DATE(h.createdAt) <= :to)
+            GROUP BY DATE(h.createdAt)
          ORDER BY DATE(h.createdAt) ASC
         """)
     List<DailyHistoryResponseDto> getUserDailyHistory(


### PR DESCRIPTION
## 📝 작업 내용 (Description)

유저 히스토리 조회 500 에러 해결
- getUserDailyHistory 쿼리 group by 추가