### PR TITLE
[SWM-227] Refresh Token 처리 변경

### DIFF
--- a/src/main/java/com/climbx/climbx/common/config/S3Config.java
+++ b/src/main/java/com/climbx/climbx/common/config/S3Config.java
@@ -24,18 +24,18 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
-                .build();
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)))
+            .build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
-                .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
-                .build();
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)))
+            .build();
     }
 } 

--- a/src/main/java/com/climbx/climbx/video/dto/VideoUploadResponseDto.java
+++ b/src/main/java/com/climbx/climbx/video/dto/VideoUploadResponseDto.java
@@ -8,4 +8,5 @@ public record VideoUploadResponseDto(
     UUID videoId,
     String presignedUrl
 ) {
-} 
+
+}

--- a/src/main/java/com/climbx/climbx/video/repository/VideoRepository.java
+++ b/src/main/java/com/climbx/climbx/video/repository/VideoRepository.java
@@ -5,4 +5,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VideoRepository extends JpaRepository<VideoEntity, UUID> {
-} 
+
+}

--- a/src/main/resources/application-auth-dev.yml
+++ b/src/main/resources/application-auth-dev.yml
@@ -31,7 +31,7 @@ auth:
     secret: ${JWT_SECRET:default-secret-key-for-development-only-change-in-production}
     access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600} # 1시간 (초 단위)
     refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600} # 2주 (초 단위)
-    issuer: ${JWT_ISSUER:climbx-api-dev}
+    issuer: ${JWT_ISSUER:urn:climbx:api-dev}
     audience: ${JWT_AUDIENCE:climbx-client}
     jws-algorithm: ${JWT_JWS_ALGORITHM:HS256}
 


### PR DESCRIPTION
## 📝 작업 내용 (Description)
Refresh Token을 http only cookie로 전달하던 기존 구현에서, 쿠키 전달을 제거하고 응답 헤더에 "Refresh-Token"으로 전달하는 방식으로 변경함. 

## 💬 리뷰어에게 (To Reviewer)
- 컨벤션 확인 부탁드려요

## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**