### PR TITLE
[SWM-247] 클라이밍장 조회 시 2D 맵 반환 구현 및 2D 맵 등록 Admin API 구현

### DIFF
--- a/.github/workflows/dev-cicd-workflow.yml
+++ b/.github/workflows/dev-cicd-workflow.yml
@@ -122,6 +122,7 @@ jobs:
               -e AWS_S3_PROFILE_IMAGE_BUCKET_NAME='${{ secrets.AWS_S3_PROFILE_IMAGE_BUCKET_NAME }}' \
               -e AWS_S3_PRESIGNED_URL_EXPIRATION='${{ secrets.AWS_S3_PRESIGNED_URL_EXPIRATION }}' \
               -e AWS_S3_PROBLEM_IMAGE_BUCKET_NAME='${{ secrets.AWS_S3_PROBLEM_IMAGE_BUCKET_NAME }}' \
+              -e AWS_S3_CLIMBING_GYM_IMAGE_BUCKET_NAME='${{ secrets.AWS_S3_CLIMBING_GYM_IMAGE_BUCKET_NAME }}' \
               -e AWS_CLOUDFRONT_DOMAIN='${{ secrets.AWS_CLOUDFRONT_DOMAIN }}' \
               -e AWS_S3_REGION='${{ vars.AWS_S3_REGION }}' \
               -e AWS_ACCESS_KEY_ID='${{ secrets.AWS_ACCESS_KEY_ID }}' \

--- a/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminGymApiDocumentation.java
+++ b/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminGymApiDocumentation.java
@@ -1,0 +1,221 @@
+package com.climbx.climbx.admin.submissions.controller;
+
+import com.climbx.climbx.common.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.multipart.MultipartFile;
+
+@Validated
+@Tag(name = "Admin Gym", description = "관리자 클라이밍장 관리 API")
+public interface AdminGymApiDocumentation {
+
+    @Operation(
+        summary = "클라이밍장 2D 맵 이미지 업로드",
+        description = "관리자가 클라이밍장의 2D 맵 이미지를 업로드합니다. 기본 이미지 1개와 오버레이 이미지 여러 개를 S3에 업로드하고, 데이터베이스에 CDN URL을 JSON 형태로 저장합니다."
+    )
+    @SecurityRequirement(name = "Bearer Authentication")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "2D 맵 이미지 업로드 완료",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = @ExampleObject(
+                    name = "업로드 성공",
+                    value = """
+                        {
+                          "httpStatus": 200,
+                          "statusMessage": "SUCCESS",
+                          "timeStamp": "2024-01-01T10:00:00Z",
+                          "responseTimeMs": 2340,
+                          "path": "/api/admin/gyms/upload/2d-map",
+                          "data": null
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 데이터",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = {
+                    @ExampleObject(
+                        name = "필수 파라미터 누락",
+                        value = """
+                            {
+                              "httpStatus": 400,
+                              "statusMessage": "필수 파라미터가 누락되었습니다.",
+                              "timeStamp": "2024-01-01T10:00:00Z",
+                              "responseTimeMs": 45,
+                              "path": "/api/admin/gyms/upload/2d-map",
+                              "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "지원하지 않는 파일 형식",
+                        value = """
+                            {
+                              "httpStatus": 400,
+                              "statusMessage": "지원하지 않는 파일 형식입니다.",
+                              "timeStamp": "2024-01-01T10:00:00Z",
+                              "responseTimeMs": 67,
+                              "path": "/api/admin/gyms/upload/2d-map",
+                              "data": null
+                            }
+                            """
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증되지 않은 사용자",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = @ExampleObject(
+                    name = "인증되지 않은 사용자",
+                    value = """
+                        {
+                          "httpStatus": 401,
+                          "statusMessage": "인증이 필요합니다.",
+                          "timeStamp": "2024-01-01T10:00:00Z",
+                          "responseTimeMs": 23,
+                          "path": "/api/admin/gyms/upload/2d-map",
+                          "data": null
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "권한 없음 (관리자 권한 필요)",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = @ExampleObject(
+                    name = "관리자 권한 없음",
+                    value = """
+                        {
+                          "httpStatus": 403,
+                          "statusMessage": "관리자 권한이 필요합니다.",
+                          "timeStamp": "2024-01-01T10:00:00Z",
+                          "responseTimeMs": 34,
+                          "path": "/api/admin/gyms/upload/2d-map",
+                          "data": null
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "클라이밍장을 찾을 수 없음",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = @ExampleObject(
+                    name = "클라이밍장 없음",
+                    value = """
+                        {
+                          "httpStatus": 404,
+                          "statusMessage": "해당 클라이밍장을 찾을 수 없습니다.",
+                          "timeStamp": "2024-01-01T10:00:00Z",
+                          "responseTimeMs": 89,
+                          "path": "/api/admin/gyms/upload/2d-map",
+                          "data": null
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "413",
+            description = "파일 크기 초과",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = @ExampleObject(
+                    name = "파일 크기 초과",
+                    value = """
+                        {
+                          "httpStatus": 413,
+                          "statusMessage": "업로드 파일 크기가 허용된 한도를 초과했습니다.",
+                          "timeStamp": "2024-01-01T10:00:00Z",
+                          "responseTimeMs": 156,
+                          "path": "/api/admin/gyms/upload/2d-map",
+                          "data": null
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                schema = @Schema(implementation = ApiResponseDto.class),
+                examples = {
+                    @ExampleObject(
+                        name = "S3 업로드 실패",
+                        value = """
+                            {
+                              "httpStatus": 500,
+                              "statusMessage": "S3 업로드 중 오류가 발생했습니다.",
+                              "timeStamp": "2024-01-01T10:00:00Z",
+                              "responseTimeMs": 1234,
+                              "path": "/api/admin/gyms/upload/2d-map",
+                              "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "서버 오류",
+                        value = """
+                            {
+                              "httpStatus": 500,
+                              "statusMessage": "서버 내부 오류가 발생했습니다.",
+                              "timeStamp": "2024-01-01T10:00:00Z",
+                              "responseTimeMs": 123,
+                              "path": "/api/admin/gyms/upload/2d-map",
+                              "data": null
+                            }
+                            """
+                    )
+                }
+            )
+        )
+    })
+    void uploadGym2dMap(
+        @Parameter(
+            name = "gymId",
+            description = "2D 맵을 업로드할 클라이밍장의 ID",
+            required = true,
+            example = "1"
+        )
+        Long gymId,
+
+        @Parameter(
+            name = "baseImage",
+            description = "클라이밍장의 기본 2D 맵 이미지 파일 (PNG, JPG, JPEG 지원)",
+            required = true
+        )
+        MultipartFile baseImage,
+
+        @Parameter(
+            name = "overlayImages",
+            description = "클라이밍장의 오버레이 2D 맵 이미지 파일들 (벽이름.png 형태로 업로드, PNG, JPG, JPEG 지원)",
+            required = true
+        )
+        List<MultipartFile> overlayImages
+    );
+}

--- a/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminGymController.java
+++ b/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminGymController.java
@@ -1,0 +1,34 @@
+package com.climbx.climbx.admin.submissions.controller;
+
+import com.climbx.climbx.admin.submissions.service.AdminGymService;
+import com.climbx.climbx.common.annotation.SuccessStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/gyms")
+@RequiredArgsConstructor
+public class AdminGymController {
+
+    private final AdminGymService adminGymService;
+
+    @PostMapping("/upload/2d-map")
+    @SuccessStatus(HttpStatus.OK)
+    public void uploadGym2dMap(
+        @RequestPart(name = "gymId") Long gymId,
+        @RequestPart(name = "baseImage") MultipartFile baseImage,
+        @RequestPart(name = "overlayImages") List<MultipartFile> overlayImages // 벽이름.png 형태로 업로드해야됨
+    ) {
+
+        adminGymService.uploadGym2dMap(gymId, baseImage, overlayImages);
+    }
+
+}

--- a/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminGymController.java
+++ b/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminGymController.java
@@ -16,10 +16,11 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/admin/gyms")
 @RequiredArgsConstructor
-public class AdminGymController {
+public class AdminGymController implements AdminGymApiDocumentation {
 
     private final AdminGymService adminGymService;
 
+    @Override
     @PostMapping("/upload/2d-map")
     @SuccessStatus(HttpStatus.OK)
     public void uploadGym2dMap(
@@ -27,7 +28,6 @@ public class AdminGymController {
         @RequestPart(name = "baseImage") MultipartFile baseImage,
         @RequestPart(name = "overlayImages") List<MultipartFile> overlayImages // 벽이름.png 형태로 업로드해야됨
     ) {
-
         adminGymService.uploadGym2dMap(gymId, baseImage, overlayImages);
     }
 

--- a/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminSubmissionApiDocumentation.java
+++ b/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminSubmissionApiDocumentation.java
@@ -1,4 +1,4 @@
-package com.climbx.climbx.admin.submissions;
+package com.climbx.climbx.admin.submissions.controller;
 
 import com.climbx.climbx.admin.submissions.dto.SubmissionReviewRequestDto;
 import com.climbx.climbx.admin.submissions.dto.SubmissionReviewResponseDto;

--- a/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminSubmissionController.java
+++ b/src/main/java/com/climbx/climbx/admin/submissions/controller/AdminSubmissionController.java
@@ -1,4 +1,4 @@
-package com.climbx.climbx.admin.submissions;
+package com.climbx.climbx.admin.submissions.controller;
 
 import com.climbx.climbx.admin.submissions.dto.SubmissionReviewRequestDto;
 import com.climbx.climbx.admin.submissions.dto.SubmissionReviewResponseDto;

--- a/src/main/java/com/climbx/climbx/admin/submissions/service/AdminGymService.java
+++ b/src/main/java/com/climbx/climbx/admin/submissions/service/AdminGymService.java
@@ -1,0 +1,44 @@
+package com.climbx.climbx.admin.submissions.service;
+
+import com.climbx.climbx.common.service.S3Service;
+import com.climbx.climbx.gym.dto.Gym2dMapInfo;
+import com.climbx.climbx.gym.entity.GymEntity;
+import com.climbx.climbx.gym.exception.GymNotFoundException;
+import com.climbx.climbx.gym.repository.GymRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminGymService {
+
+    private final S3Service s3Service;
+    private final GymRepository gymRepository;
+
+    @Transactional
+    public void uploadGym2dMap(
+        Long gymId,
+        MultipartFile baseImage,
+        List<MultipartFile> overlayImages
+    ) {
+        log.info("클라이밍장 2D 맵 업로드 시작: gymId={}, baseImage={}, overlayMapImages={}",
+            gymId, baseImage.getOriginalFilename(), overlayImages.size());
+
+        // 클라이밍장 존재 여부 확인
+        GymEntity gym = gymRepository.findById(gymId)
+            .orElseThrow(() -> new GymNotFoundException(gymId));
+
+        // S3에 이미지들 업로드하고 CDN URL들 받아오기
+        Gym2dMapInfo gym2dMapInfo = s3Service.uploadGym2dMapImages(gymId, baseImage, overlayImages);
+
+        gym.setMap2dUrls(gym2dMapInfo);
+
+        log.info("클라이밍장 2D 맵 업로드 완료: gymId={}, baseMapUrl={}, overlayMapUrls={}",
+            gymId, gym2dMapInfo.baseMapUrl(), gym2dMapInfo.overlayMapUrls().size());
+    }
+}

--- a/src/main/java/com/climbx/climbx/common/util/FileUploadUtils.java
+++ b/src/main/java/com/climbx/climbx/common/util/FileUploadUtils.java
@@ -39,4 +39,12 @@ public class FileUploadUtils {
         return String.format("problem-images/area-%d/%s-%s%s", gymAreaId, now, problemId,
             fileExtension);
     }
+
+    public static String generateGym2dMapBaseImageKey(Long gymId, String imageName) {
+        return String.format("2d-map/%d/base-images/%s", gymId, imageName);
+    }
+
+    public static String generateGym2dMapOverlayImageKey(Long gymId, String imageName) {
+        return String.format("2d-map/%d/overlay-images/%s", gymId, imageName);
+    }
 }

--- a/src/main/java/com/climbx/climbx/gym/GymApiDocumentation.java
+++ b/src/main/java/com/climbx/climbx/gym/GymApiDocumentation.java
@@ -49,7 +49,11 @@ public interface GymApiDocumentation {
                             "longitude": 126.9780,
                             "address": "서울시 강남구 테헤란로 123",
                             "phoneNumber": "02-1234-5678",
-                            "map2DUrl": "https://example.com/map/gym1"
+                            "baseMapUrl": "https://cdn-url/2d-map/1/base-images/1-base.png",
+                            "overlayMapUrls": [
+                                "https://cdn-url/2d-map/1/overlay-images/1-사과.jpeg",
+                                "https://cdn-url/2d-map/1/overlay-images/1-배1.png"
+                            ]
                           }
                         }
                         """
@@ -148,7 +152,11 @@ public interface GymApiDocumentation {
                               "longitude": 126.9780,
                               "address": "서울시 강남구 테헤란로 123",
                               "phoneNumber": "02-1234-5678",
-                              "map2DUrl": "https://example.com/map/gym1"
+                              "baseMapUrl": "https://cdn-url/2d-map/1/base-images/1-base.png",
+                              "overlayMapUrls": [
+                                  "https://cdn-url/2d-map/1/overlay-images/1-사과.jpeg",
+                                  "https://cdn-url/2d-map/1/overlay-images/1-배1.png"
+                              ]
                             },
                             {
                               "gymId": 2,
@@ -157,7 +165,11 @@ public interface GymApiDocumentation {
                               "longitude": 127.0320,
                               "address": "서울시 서초구 강남대로 456",
                               "phoneNumber": "02-9876-5432",
-                              "map2DUrl": "https://example.com/map/gym2"
+                              "baseMapUrl": "https://cdn-url/2d-map/1/base-images/1-base.png",
+                              "overlayMapUrls": [
+                                  "https://cdn-url/2d-map/1/overlay-images/1-사과.jpeg",
+                                  "https://cdn-url/2d-map/1/overlay-images/1-배1.png"
+                              ]
                             }
                           ]
                         }
@@ -234,7 +246,11 @@ public interface GymApiDocumentation {
                               "longitude": 126.9780,
                               "address": "서울시 강남구 테헤란로 123",
                               "phoneNumber": "02-1234-5678",
-                              "map2DUrl": "https://example.com/map/gym1"
+                              "baseMapUrl": "https://cdn-url/2d-map/1/base-images/1-base.png",
+                              "overlayMapUrls": [
+                                  "https://cdn-url/2d-map/1/overlay-images/1-사과.jpeg",
+                                  "https://cdn-url/2d-map/1/overlay-images/1-배1.png"
+                              ]
                             },
                             {
                               "gymId": 3,
@@ -243,7 +259,11 @@ public interface GymApiDocumentation {
                               "longitude": 127.0396,
                               "address": "서울시 강남구 역삼로 789",
                               "phoneNumber": "02-5555-1234",
-                              "map2DUrl": "https://example.com/map/gym3"
+                              "baseMapUrl": "https://cdn-url/2d-map/1/base-images/1-base.png",
+                              "overlayMapUrls": [
+                                  "https://cdn-url/2d-map/1/overlay-images/1-사과.jpeg",
+                                  "https://cdn-url/2d-map/1/overlay-images/1-배1.png"
+                              ]
                             }
                           ]
                         }

--- a/src/main/java/com/climbx/climbx/gym/dto/Gym2dMapInfo.java
+++ b/src/main/java/com/climbx/climbx/gym/dto/Gym2dMapInfo.java
@@ -1,0 +1,11 @@
+package com.climbx.climbx.gym.dto;
+
+import java.util.List;
+
+public record Gym2dMapInfo(
+
+    String baseMapUrl,
+    List<String> overlayMapUrls
+) {
+
+}

--- a/src/main/java/com/climbx/climbx/gym/dto/GymInfoResponseDto.java
+++ b/src/main/java/com/climbx/climbx/gym/dto/GymInfoResponseDto.java
@@ -1,6 +1,7 @@
 package com.climbx.climbx.gym.dto;
 
 import com.climbx.climbx.gym.entity.GymEntity;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -12,7 +13,8 @@ public record GymInfoResponseDto(
     Double longitude,
     String address,
     String phoneNumber,
-    String map2dUrl
+    String baseMapUrl,
+    List<String> overlayMapUrls
 ) {
 
     public static GymInfoResponseDto from(GymEntity gym) {
@@ -23,7 +25,12 @@ public record GymInfoResponseDto(
             .longitude(gym.longitude())
             .address(gym.address())
             .phoneNumber(gym.phoneNumber())
-            .map2dUrl(gym.map2dUrl())
+            .baseMapUrl(gym.map2dUrls() == null ? null : gym.map2dUrls().baseMapUrl())
+            .overlayMapUrls(gym.map2dUrls() == null
+                ? List.of()
+                : gym.map2dUrls().overlayMapUrls() == null
+                    ? List.of()
+                    : gym.map2dUrls().overlayMapUrls())
             .build();
     }
 }

--- a/src/main/java/com/climbx/climbx/gym/entity/GymEntity.java
+++ b/src/main/java/com/climbx/climbx/gym/entity/GymEntity.java
@@ -1,6 +1,7 @@
 package com.climbx.climbx.gym.entity;
 
 import com.climbx.climbx.common.entity.BaseTimeEntity;
+import com.climbx.climbx.gym.dto.Gym2dMapInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -19,6 +20,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "gyms")
@@ -57,8 +60,13 @@ public class GymEntity extends BaseTimeEntity {
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$")
     private String phoneNumber; // 전화번호, 형식: 010-1234-5678
 
-    @Column(name = "map_2d_url", length = 255)
-    private String map2dUrl; // 2D 지도 URL
+    @Column(name = "map_2d_urls", columnDefinition = "JSON")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Gym2dMapInfo map2dUrls; // 2D 지도 URL 목록
+
+    public void setMap2dUrls(Gym2dMapInfo gym2dMapInfo) {
+        this.map2dUrls = gym2dMapInfo;
+    }
 
     // Todo : 매장 메타데이터 json 컬럼
 }

--- a/src/main/resources/application-aws-dev.yml
+++ b/src/main/resources/application-aws-dev.yml
@@ -8,6 +8,7 @@ aws:
     videos-source-bucket-name: ${AWS_S3_VIDEOS_SOURCE_BUCKET_NAME}
     profile-image-bucket-name: ${AWS_S3_PROFILE_IMAGE_BUCKET_NAME}
     problem-image-bucket-name: ${AWS_S3_PROBLEM_IMAGE_BUCKET_NAME}
+    climbing-gym-image-bucket-name: ${AWS_S3_CLIMBING_GYM_IMAGE_BUCKET_NAME}
     presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:180} # in seconds
     region: ${AWS_S3_REGION:ap-northeast-2}
     access-key: ${AWS_ACCESS_KEY_ID}

--- a/src/main/resources/db/init/data.sql
+++ b/src/main/resources/db/init/data.sql
@@ -133,35 +133,34 @@ INSERT INTO gyms (name,
                   longitude,
                   address,
                   phone_number,
-                  map_2d_url,
                   created_at,
                   updated_at)
 VALUES ('더클라임 클라이밍 B 홍대점', 37.5546882, 126.9202997, '서울 마포구 양화로 125 경남관광빌딩', '02-332-5014',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 일산점', 37.6507188, 126.7788853, '경기 고양시 일산동구 중앙로 1160 5층 더클라임', '031-905-5014',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 마곡점', 37.5606786, 126.8337683, '서울 강서구 마곡동로 62 마곡사이언스타워 7층', '02-2668-5014',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 양재점', 37.4851386, 127.0358583, '서울 강남구 남부순환로 2615 지하1층', '02-576-8821',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 신림점', 37.4821999, 126.928909, '서울 관악구 신원로 35 삼모더프라임타워 5층', '02-877-8821',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 연남점', 37.5576629, 126.9257955, '서울 마포구 양화로 186 3층', '02-2088-5071',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 강남점', 37.4975157, 127.0319786, '서울 강남구 테헤란로8길 21 화인강남빌딩 B1층', '02-566-8821',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 사당점', 37.4743761, 126.9814529, '서울 관악구 과천대로 939 지층 B201호', '02-585-8821',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 신사점', 37.521096, 127.019134, '서울 강남구 압구정로2길 6 지하2층', '02-549-8821',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 논현점', 37.5082918, 127.0222621, '서울 서초구 강남대로 519 지하1층', '02-545-5014',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 문래점', 37.5206605, 126.8950132, '서울 영등포구 당산로 63 1동', '02-3667-5014',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 이수점', 37.4818365, 126.981545, '서울 동작구 동작대로 59 지하1층', '02-588-5014',
-        'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        ('더클라임 클라이밍 성수점', 37.5463876, 127.0650498, '서울 성동구 아차산로17길 49 생각공장 데시앙플렉스 B1층',
-        '02-499-5014', 'http://fake-url', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+        '02-499-5014', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 
 -- Gym Areas
@@ -761,3 +760,4 @@ VALUES ((UNHEX(REPLACE("3f06af63-a93c-11e4-9797-00505690773f", "-", ""))),
 
 
 COMMIT;
+

--- a/src/test/java/com/climbx/climbx/fixture/GymFixture.java
+++ b/src/test/java/com/climbx/climbx/fixture/GymFixture.java
@@ -1,13 +1,17 @@
 package com.climbx.climbx.fixture;
 
+import com.climbx.climbx.gym.dto.Gym2dMapInfo;
 import com.climbx.climbx.gym.dto.GymInfoResponseDto;
 import com.climbx.climbx.gym.entity.GymEntity;
+import java.util.List;
 
 public class GymFixture {
 
     public static final String ADDRESS = "서울시 마포구 공덕";
     public static final String PHONE_NUMBER = "02-1234-5678";
-    public static final String MAP_2D_URL = "http://example.com/map2d";
+    public static final Gym2dMapInfo gym2dMapInfo = new Gym2dMapInfo(
+        "https://example.com/base-map.png",
+        List.of("https://example.com/overlay-map1.png", "https://example.com/overlay-map2.png"));
 
     public static GymEntity createGymEntity(Long gymId, String name, Double latitude,
         Double longitude) {
@@ -18,7 +22,7 @@ public class GymFixture {
             .longitude(longitude)
             .address(ADDRESS)
             .phoneNumber(PHONE_NUMBER)
-            .map2dUrl(MAP_2D_URL)
+            .map2dUrls(gym2dMapInfo)
             .build();
     }
 
@@ -31,7 +35,8 @@ public class GymFixture {
             .longitude(longitude)
             .address(ADDRESS)
             .phoneNumber(PHONE_NUMBER)
-            .map2dUrl(MAP_2D_URL)
+            .baseMapUrl(gym2dMapInfo.baseMapUrl())
+            .overlayMapUrls(gym2dMapInfo.overlayMapUrls())
             .build();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 클라이밍장 조회 시, 2D 맵의 CDN URL을 같이 반환하도록 수정함
- 매장의 전체 맵 사진 = `String baseMapUrl`
- 매장 내의 각 벽에 대한 사진들 = `List overlayMapUrls`
- 2D 맵을 등록하는 어드민 API를 구현함

## ✨ 변경 사항 (Changes)

- 클라이밍장 조회 응답 형식 변경

## 🚀관련 이슈 (Related Issue)

SWM-247

## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**