### PR TITLE
[SWM-255] fix: 서버에서 유저 랭킹을 계산해서 반환하도록 수정

### DIFF
--- a/src/main/java/com/climbx/climbx/ranking/RankingApiDocumentation.java
+++ b/src/main/java/com/climbx/climbx/ranking/RankingApiDocumentation.java
@@ -63,19 +63,21 @@ public interface RankingApiDocumentation {
                             "totalPage": 15,
                             "rankingList": [
                               {
-                                "nickname": "alice",
-                                "statusMessage": "열심히 클라이밍 중!",
-                                "profileImageUrl": "https://example.com/profile/alice.jpg",
-                                "rating": 1800,
-                                "currentStreak": 25,
-                                "longestStreak": 45,
-                                "solvedCount": 120
+                                "nickname": "ivan",
+                                "statusMessage": "bouldering beast.",
+                                "profileImageCdnUrl": "/images/ivan.png",
+                                "rating": 3000,
+                                "ranking": 1,
+                                "currentStreak": 50,
+                                "longestStreak": 50,
+                                "solvedCount": 400
                               },
                               {
                                 "nickname": "bob",
                                 "statusMessage": "클라이밍 마스터가 되겠다!",
-                                "profileImageUrl": "https://example.com/profile/bob.jpg",
+                                "profileImageCdnUrl": "https://example.com/profile/bob.jpg",
                                 "rating": 1650,
+                                "ranking": 2,
                                 "currentStreak": 12,
                                 "longestStreak": 30,
                                 "solvedCount": 85

--- a/src/main/java/com/climbx/climbx/ranking/dto/UserRankingResponseDto.java
+++ b/src/main/java/com/climbx/climbx/ranking/dto/UserRankingResponseDto.java
@@ -10,16 +10,18 @@ public record UserRankingResponseDto(
     String statusMessage,
     String profileImageCdnUrl, // null 허용
     Integer rating,
+    Long ranking,
     Integer currentStreak,
     Integer longestStreak,
     Integer solvedCount
 ) {
 
-    public static UserRankingResponseDto from(UserStatEntity user) {
+    public static UserRankingResponseDto from(UserStatEntity user, Long ranking) {
         return UserRankingResponseDto.builder()
             .nickname(user.userAccountEntity().nickname())
             .statusMessage(user.userAccountEntity().statusMessage())
             .profileImageCdnUrl(user.userAccountEntity().profileImageCdnUrl())
+            .ranking(ranking)
             .rating(user.rating())
             .currentStreak(user.currentStreak())
             .longestStreak(user.longestStreak())

--- a/src/main/java/com/climbx/climbx/ranking/service/RankingService.java
+++ b/src/main/java/com/climbx/climbx/ranking/service/RankingService.java
@@ -7,8 +7,10 @@ import com.climbx.climbx.ranking.dto.UserRankingResponseDto;
 import com.climbx.climbx.ranking.repository.RankingRepository;
 import com.climbx.climbx.user.entity.UserStatEntity;
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -43,8 +46,16 @@ public class RankingService {
         Page<UserStatEntity> rankingPage = rankingRepository.findAllByUserRole(sortedPageable,
             RoleType.USER);
 
-        List<UserRankingResponseDto> rankingList = rankingPage.getContent().stream()
-            .map(UserRankingResponseDto::from)
+        List<UserStatEntity> userStats = rankingPage.getContent();
+
+        Long startRank = pageable.getOffset() + 1;
+
+        log.debug("랭킹 조회: criteria={}, page={}, size={}, totalElements={}, startRank={}",
+            criteria, pageable.getPageNumber(), pageable.getPageSize(),
+            rankingPage.getTotalElements(), startRank);
+
+        List<UserRankingResponseDto> rankingList = IntStream.range(0, userStats.size())
+            .mapToObj(i -> UserRankingResponseDto.from(userStats.get(i), startRank + i))
             .toList();
 
         // 페이징 정보 계산


### PR DESCRIPTION
## 📝 작업 내용 (Description)
모바일에서 유저 랭킹 리스트를 조회한 뒤, 직접 랭킹을 계산하여 보여주고 있었음.
그러나, 매번 페이지네이션 할 때마다 1부터 랭킹이 조회 되는 문제 발생
따라서 서버에서 각 유저의 랭킹을 응답값에 포함하도록 수정하였습니다.

## ✨ 변경 사항 (Changes)

- `GET /api/ranking/users` API의 응답값에 `ranking`이 추가됨

## 🚀관련 이슈 (Related Issue)

SWM-255


## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**