### PR TITLE
[SWM-268] feat: 유저 프로필 카테고리 레이팅 개선

### DIFF
--- a/src/main/java/com/climbx/climbx/problem/enums/ProblemTagType.java
+++ b/src/main/java/com/climbx/climbx/problem/enums/ProblemTagType.java
@@ -11,25 +11,26 @@ import lombok.experimental.Accessors;
 @RequiredArgsConstructor
 public enum ProblemTagType {
 
-    PINCH_HOLD("핀치 홀드"),
-    CRIMP_HOLD("크림프 홀드"),
-    SLOPER_HOLD("슬로퍼 홀드"),
-    POCKET_HOLD("포켓 홀드"),
+    PINCH_HOLD("핀치 홀드", 3),
+    CRIMP_HOLD("크림프 홀드", 7),
+    SLOPER_HOLD("슬로퍼 홀드", 8),
+    POCKET_HOLD("포켓 홀드", 9),
 
-    TOE_HOOK("토 훅"),
-    HEEL_HOOK("힐 훅"),
-    DROP_KNEE("드롭 니"),
+    TOE_HOOK("토 훅", 10),
+    HEEL_HOOK("힐 훅", 6),
+    DROP_KNEE("드롭 니", 7),
 
-    REACH("리치"),
-    BALANCE("밸런스"),
-    OVERHANG("오버행"),
-    BATHANG("배트행"),
+    REACH("리치", 11),
+    BALANCE("밸런스", 14),
+    OVERHANG("오버행", 4),
+    BATHANG("배트행", 5),
 
-    LUNGE("런지"),
-    DYNO("다이노"),
-    COORDINATE("코디네이션");
+    LUNGE("런지", 2),
+    DYNO("다이노", 13),
+    COORDINATE("코디네이션", 1);
 
     private final String displayName;
+    private final int priority;
 
     public static ProblemTagType from(String name) {
         return OptionalUtil.tryOf(() -> valueOf(name))


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 유저 프로필 조회 시 카테고리 레이팅이 항상 8개를 반환하도록 개선
- 동일한 레이팅을 가진 태그에 우선순위 적용하여 일관된 정렬 제공

## ✨ 변경 사항 (Changes)

- [x] ProblemTagType enum에 priority 필드 추가 (홀드 타입 → 테크닉 → 체형/환경 → 동적 움직임 순)
- [x] RatingUtil.calculateCategoryRating에서 모든 태그 타입을 대상으로 처리하도록 수정
- [x] 유저가 해결하지 않은 태그는 0점으로 계산하여 상위 8개 태그 반환
- [x] 동일 레이팅 시 priority 기준으로 정렬하되 API 응답에는 우선순위 정보 비노출

## ✅ 테스트 방법 (How to Test)

1. `./gradlew build` - 빌드 및 테스트 통과 확인
2. 유저 프로필 API 호출하여 카테고리 레이팅이 항상 8개 반환되는지 확인
3. 동일한 레이팅을 가진 태그들이 일관된 순서로 정렬되는지 확인

## 💬 리뷰어에게 (To Reviewer)

- 기존 로직을 유지하면서 최소한의 변경으로 요구사항 구현
- 우선순위 정보는 내부 정렬용으로만 사용하고 API 응답에는 노출하지 않음
- 모든 태그 타입(14개)을 처리하되 상위 8개만 반환하는 구조 유지

## 🚀관련 이슈 (Related Issue)

Closes: SWM-268

## 📋 앞으로의 과제 (Todo)

- [ ] 필요시 태그별 우선순위 조정 고려

## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**