### PR TITLE
[SWM-283] 히스토리 조회 쿼리 집계 제거

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -5,6 +5,7 @@ on:
 
   pull_request:
     branches: [ "develop" ]
+    types: [opened, reopened, synchronize, edited]
 
 jobs:
   test:

--- a/src/main/java/com/climbx/climbx/user/dto/DailyHistoryResponseDto.java
+++ b/src/main/java/com/climbx/climbx/user/dto/DailyHistoryResponseDto.java
@@ -8,14 +8,14 @@ import lombok.Builder;
 public record DailyHistoryResponseDto(
 
     LocalDate date,
-    Long value
+    Integer value
 ) {
 
     public DailyHistoryResponseDto(Date date, Long value) {
-        this(date.toLocalDate(), value);
+        this(date.toLocalDate(), value.intValue());
     }
 
     public DailyHistoryResponseDto(Date date, Integer value) {
-        this(date.toLocalDate(), value.longValue());
+        this(date.toLocalDate(), value);
     }
 }

--- a/src/main/java/com/climbx/climbx/user/dto/DailyHistoryResponseDto.java
+++ b/src/main/java/com/climbx/climbx/user/dto/DailyHistoryResponseDto.java
@@ -14,4 +14,8 @@ public record DailyHistoryResponseDto(
     public DailyHistoryResponseDto(Date date, Long value) {
         this(date.toLocalDate(), value);
     }
+
+    public DailyHistoryResponseDto(Date date, Integer value) {
+        this(date.toLocalDate(), value.longValue());
+    }
 }

--- a/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
+++ b/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
@@ -26,7 +26,7 @@ public interface UserRankingHistoryRepository extends
            AND h.criteria = :criteria
            AND (:from IS NULL OR DATE(h.createdAt) >= :from)
            AND (:to IS NULL OR DATE(h.createdAt) <= :to)
-         ORDER BY DATE(h.createdAt) ASC
+         ORDER BY h.createdAt ASC
         """)
     List<DailyHistoryResponseDto> getUserDailyHistory(
         @Param("userId") Long userId,

--- a/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
+++ b/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
@@ -19,14 +19,13 @@ public interface UserRankingHistoryRepository extends
     @Query("""
         SELECT new com.climbx.climbx.user.dto.DailyHistoryResponseDto(
             DATE(h.createdAt),
-            SUM(h.value)
+            h.value
         )
           FROM UserRankingHistoryEntity h
          WHERE h.userId = :userId
            AND h.criteria = :criteria
            AND (:from IS NULL OR DATE(h.createdAt) >= :from)
            AND (:to IS NULL OR DATE(h.createdAt) <= :to)
-            GROUP BY DATE(h.createdAt)
          ORDER BY DATE(h.createdAt) ASC
         """)
     List<DailyHistoryResponseDto> getUserDailyHistory(

--- a/src/test/java/com/climbx/climbx/fixture/UserFixture.java
+++ b/src/test/java/com/climbx/climbx/fixture/UserFixture.java
@@ -289,7 +289,7 @@ public class UserFixture {
     ) {
         return DailyHistoryResponseDto.builder()
             .date(date)
-            .value((long) value)
+            .value(value)
             .build();
     }
 

--- a/src/test/java/com/climbx/climbx/user/service/UserAnalyticsServiceTest.java
+++ b/src/test/java/com/climbx/climbx/user/service/UserAnalyticsServiceTest.java
@@ -178,9 +178,9 @@ class UserAnalyticsServiceTest {
 
             UserAccountEntity user = createMockUserAccountEntity(userId, nickname);
             List<DailyHistoryResponseDto> expectedHistory = List.of(
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 1), 3L),
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 2), 2L),
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 3), 5L)
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 1), 3),
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 2), 2),
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 3), 5)
             );
 
             given(userLookupService.findUserByNickname(nickname)).willReturn(user);
@@ -195,9 +195,9 @@ class UserAnalyticsServiceTest {
             // then
             assertThat(result).hasSize(3);
             assertThat(result.get(0).date()).isEqualTo(LocalDate.of(2024, 1, 1));
-            assertThat(result.get(0).value()).isEqualTo(3L);
-            assertThat(result.get(1).value()).isEqualTo(2L);
-            assertThat(result.get(2).value()).isEqualTo(5L);
+            assertThat(result.get(0).value()).isEqualTo(3);
+            assertThat(result.get(1).value()).isEqualTo(2);
+            assertThat(result.get(2).value()).isEqualTo(5);
 
             then(userLookupService).should().findUserByNickname(nickname);
             then(submissionRepository).should()
@@ -237,7 +237,7 @@ class UserAnalyticsServiceTest {
 
             UserAccountEntity user = createMockUserAccountEntity(userId, nickname);
             List<DailyHistoryResponseDto> expectedHistory = List.of(
-                new DailyHistoryResponseDto(date, 3L)
+                new DailyHistoryResponseDto(date, 3)
             );
 
             given(userLookupService.findUserByNickname(nickname)).willReturn(user);
@@ -252,7 +252,7 @@ class UserAnalyticsServiceTest {
             // then
             assertThat(result).hasSize(1);
             assertThat(result.get(0).date()).isEqualTo(date);
-            assertThat(result.get(0).value()).isEqualTo(3L);
+            assertThat(result.get(0).value()).isEqualTo(3);
         }
     }
 
@@ -272,9 +272,9 @@ class UserAnalyticsServiceTest {
 
             UserAccountEntity user = createMockUserAccountEntity(userId, nickname);
             List<DailyHistoryResponseDto> expectedHistory = List.of(
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 1), 1200L),
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 2), 1250L),
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 3), 1300L)
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 1), 1200),
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 2), 1250),
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 3), 1300)
             );
 
             given(userLookupService.findUserByNickname(nickname)).willReturn(user);
@@ -288,9 +288,9 @@ class UserAnalyticsServiceTest {
 
             // then
             assertThat(result).hasSize(3);
-            assertThat(result.get(0).value()).isEqualTo(1200L);
-            assertThat(result.get(1).value()).isEqualTo(1250L);
-            assertThat(result.get(2).value()).isEqualTo(1300L);
+            assertThat(result.get(0).value()).isEqualTo(1200);
+            assertThat(result.get(1).value()).isEqualTo(1250);
+            assertThat(result.get(2).value()).isEqualTo(1300);
 
             then(userLookupService).should().findUserByNickname(nickname);
             then(userRankingHistoryRepository).should()
@@ -309,9 +309,9 @@ class UserAnalyticsServiceTest {
 
             UserAccountEntity user = createMockUserAccountEntity(userId, nickname);
             List<DailyHistoryResponseDto> expectedHistory = List.of(
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 1), 10L),
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 2), 12L),
-                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 3), 15L)
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 1), 10),
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 2), 12),
+                new DailyHistoryResponseDto(LocalDate.of(2024, 1, 3), 15)
             );
 
             given(userLookupService.findUserByNickname(nickname)).willReturn(user);
@@ -325,9 +325,9 @@ class UserAnalyticsServiceTest {
 
             // then
             assertThat(result).hasSize(3);
-            assertThat(result.get(0).value()).isEqualTo(10L);
-            assertThat(result.get(1).value()).isEqualTo(12L);
-            assertThat(result.get(2).value()).isEqualTo(15L);
+            assertThat(result.get(0).value()).isEqualTo(10);
+            assertThat(result.get(1).value()).isEqualTo(12);
+            assertThat(result.get(2).value()).isEqualTo(15);
 
             then(userRankingHistoryRepository).should()
                 .getUserDailyHistory(userId, criteria, from, to);


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 일일 히스토리 조회 시 불필요한 집계 연산 제거
- GitHub Actions 테스트 워크플로우 PR 트리거 이벤트 타입 추가

## ✨ 변경 사항 (Changes)

- [x] UserRankingHistoryRepository에서 SUM() 및 GROUP BY 절 제거
- [x] DailyHistoryResponseDto에 Value를 Integer로 받는 생성자 추가
- [x] 개별 히스토리 값을 반환하도록 쿼리 수정
- [x] test workflow 트리거 types: [opened, reopened, synchronize, edited] 추가

## 🚀관련 이슈 (Related Issue)

Closes: SWM-283

## 💎 **To. Gemini Code Assistant**

> 아래 가이드라인에 맞춰 PR 요약, 코드 리뷰를 진행해 주세요.

* **리뷰 언어:** **모든 설명과 제안은 반드시 한국어(Korean Language)로 작성해 주세요.**