### PR TITLE
[SWM-286] 투표 가능한 제출 상태를 PENDING까지 확장

### DIFF
--- a/src/main/java/com/climbx/climbx/problem/service/ProblemService.java
+++ b/src/main/java/com/climbx/climbx/problem/service/ProblemService.java
@@ -2,10 +2,8 @@ package com.climbx.climbx.problem.service;
 
 import com.climbx.climbx.common.enums.ActiveStatusType;
 import com.climbx.climbx.common.enums.ErrorCode;
-import com.climbx.climbx.common.enums.StatusType;
 import com.climbx.climbx.common.exception.InvalidParameterException;
 import com.climbx.climbx.common.service.S3Service;
-import com.climbx.climbx.problem.util.ProblemRatingUtil;
 import com.climbx.climbx.gym.entity.GymAreaEntity;
 import com.climbx.climbx.gym.entity.GymEntity;
 import com.climbx.climbx.gym.enums.GymTierType;
@@ -30,6 +28,7 @@ import com.climbx.climbx.problem.repository.ContributionRepository;
 import com.climbx.climbx.problem.repository.ContributionTagRepository;
 import com.climbx.climbx.problem.repository.ProblemRepository;
 import com.climbx.climbx.problem.repository.ProblemTagRepository;
+import com.climbx.climbx.problem.util.ProblemRatingUtil;
 import com.climbx.climbx.submission.entity.SubmissionEntity;
 import com.climbx.climbx.submission.repository.SubmissionRepository;
 import com.climbx.climbx.user.entity.UserAccountEntity;
@@ -148,10 +147,9 @@ public class ProblemService {
         UserAccountEntity user = userAccountRepository.findById(userId)
             .orElseThrow(() -> new UserNotFoundException(userId));
 
-        SubmissionEntity submission = submissionRepository.findByProblemIdAndVideoEntity_UserIdAndStatus(
-            problemId,
+        SubmissionEntity submission = submissionRepository.getVotableSubmission(
             userId,
-            StatusType.ACCEPTED
+            problemId
         ).orElseThrow(() -> new ForbiddenProblemVoteException(problemId, userId));
 
         ProblemEntity problem = submission.problemEntity();

--- a/src/main/java/com/climbx/climbx/problem/service/ProblemService.java
+++ b/src/main/java/com/climbx/climbx/problem/service/ProblemService.java
@@ -148,8 +148,8 @@ public class ProblemService {
             .orElseThrow(() -> new UserNotFoundException(userId));
 
         SubmissionEntity submission = submissionRepository.getVotableSubmission(
-            userId,
-            problemId
+            problemId,
+            userId
         ).orElseThrow(() -> new ForbiddenProblemVoteException(problemId, userId));
 
         ProblemEntity problem = submission.problemEntity();

--- a/src/main/java/com/climbx/climbx/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/climbx/climbx/submission/repository/SubmissionRepository.java
@@ -204,6 +204,17 @@ public interface SubmissionRepository extends JpaRepository<SubmissionEntity, UU
     // ProblemEntity를 fetch join
     @EntityGraph(attributePaths = "problemEntity")
     Optional<SubmissionEntity> findByProblemIdAndVideoEntity_UserIdAndStatus(
-        UUID problemId, Long userId, StatusType status
+        UUID problemId, Long userId, List<StatusType> statusTypes
     );
+
+    default Optional<SubmissionEntity> getVotableSubmission(Long userId, UUID problemId) {
+        return findByProblemIdAndVideoEntity_UserIdAndStatus(
+            problemId,
+            userId,
+            List.of(
+                StatusType.ACCEPTED,
+                StatusType.PENDING
+            )
+        );
+    }
 }

--- a/src/main/java/com/climbx/climbx/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/climbx/climbx/submission/repository/SubmissionRepository.java
@@ -203,12 +203,12 @@ public interface SubmissionRepository extends JpaRepository<SubmissionEntity, UU
 
     // ProblemEntity를 fetch join
     @EntityGraph(attributePaths = "problemEntity")
-    Optional<SubmissionEntity> findByProblemIdAndVideoEntity_UserIdAndStatus(
-        UUID problemId, Long userId, List<StatusType> statusTypes
+    Optional<SubmissionEntity> findByProblemIdAndVideoEntity_UserIdAndStatusIn(
+        UUID problemId, Long videoEntity_userId, List<StatusType> statusList
     );
 
-    default Optional<SubmissionEntity> getVotableSubmission(Long userId, UUID problemId) {
-        return findByProblemIdAndVideoEntity_UserIdAndStatus(
+    default Optional<SubmissionEntity> getVotableSubmission(UUID problemId, Long userId) {
+        return findByProblemIdAndVideoEntity_UserIdAndStatusIn(
             problemId,
             userId,
             List.of(

--- a/src/main/java/com/climbx/climbx/user/dto/DailyHistoryResponseDto.java
+++ b/src/main/java/com/climbx/climbx/user/dto/DailyHistoryResponseDto.java
@@ -14,4 +14,8 @@ public record DailyHistoryResponseDto(
     public DailyHistoryResponseDto(Date date, Long value) {
         this(date.toLocalDate(), value);
     }
+
+    public DailyHistoryResponseDto(Date date, Integer value) {
+        this(date.toLocalDate(), value.longValue());
+    }
 }

--- a/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
+++ b/src/main/java/com/climbx/climbx/user/repository/UserRankingHistoryRepository.java
@@ -19,14 +19,13 @@ public interface UserRankingHistoryRepository extends
     @Query("""
         SELECT new com.climbx.climbx.user.dto.DailyHistoryResponseDto(
             DATE(h.createdAt),
-            SUM(h.value)
+            h.value
         )
           FROM UserRankingHistoryEntity h
          WHERE h.userId = :userId
            AND h.criteria = :criteria
            AND (:from IS NULL OR DATE(h.createdAt) >= :from)
            AND (:to IS NULL OR DATE(h.createdAt) <= :to)
-            GROUP BY DATE(h.createdAt)
          ORDER BY DATE(h.createdAt) ASC
         """)
     List<DailyHistoryResponseDto> getUserDailyHistory(


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 문제 투표 시 PENDING 상태의 제출에 대해서도 투표 가능하도록 기능 확장
- findByProblemIdAndVideoEntity_UserIdAndStatusIn 호출하는 편의 메서드 getVotableSubmission 작성

## ✨ 변경 사항 (Changes)

- [x] `SubmissionRepository`에 `getVotableSubmission` 디폴트 메서드 추가
- [x] `findByProblemIdAndVideoEntity_UserIdAndStatusIn` 메서드 시그니처 변경 (단일 StatusType →
List<StatusType>)
- [x] 투표 가능 상태를 ACCEPTED에서 ACCEPTED + PENDING으로 확장